### PR TITLE
Attempt to fix 'use-after-free' issue by waiting to clean up the rust side until the whole gateway is disposed.

### DIFF
--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/gateway",
-  "version": "0.21.0-khan.1.debug",
+  "version": "0.21.0-khan.2.debug",
   "description": "Apollo Gateway",
   "author": "Apollo <opensource@apollographql.com>",
   "main": "dist/index.js",
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@apollo/federation": "0.20.4",
-    "@apollo/query-planner-wasm": "http://github.com:Khan/federation.git#apollo-query-planner-wasm-v0.0.6-khan.1.debug-gitpkg",
+    "@apollo/query-planner-wasm": "http://github.com/Khan/federation.git#apollo-query-planner-wasm-v0.0.6-khan.1.debug-gitpkg",
     "@types/node-fetch": "2.5.4",
     "apollo-graphql": "^0.6.0",
     "apollo-reporting-protobuf": "^0.6.0",

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/gateway",
-  "version": "0.21.0-khan.2.debug",
+  "version": "0.21.0-khan.3.debug",
   "description": "Apollo Gateway",
   "author": "Apollo <opensource@apollographql.com>",
   "main": "dist/index.js",

--- a/gateway-js/src/__tests__/gateway/executor.test.ts
+++ b/gateway-js/src/__tests__/gateway/executor.test.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 import { ApolloGateway } from '../../';
-import { ApolloServer } from "apollo-server";
+import { ApolloServer } from 'apollo-server';
 import { fixtures } from 'apollo-federation-integration-testsuite';
 import { Logger } from 'apollo-server-types';
 import { fetch } from '__mocks__/apollo-server-env';
@@ -56,7 +56,7 @@ describe('ApolloGateway executor', () => {
   });
 
   it('should not crash if no variables are not provided', async () => {
-    const me = { id: '1', birthDate: '1988-10-21'};
+    const me = { id: '1', birthDate: '1988-10-21' };
     fetch.mockJSONResponseOnce({ data: { me } });
     const gateway = new ApolloGateway({
       localServiceList: fixtures,
@@ -76,8 +76,7 @@ describe('ApolloGateway executor', () => {
     const { errors, data } = await executor({
       source,
       document: gql(source),
-      request: {
-      },
+      request: {},
       queryHash: 'hashed',
       context: null,
       cache: {} as any,
@@ -97,11 +96,9 @@ describe('ApolloGateway executor', () => {
 
     // Mock implementation of process.exit with another () => never function.
     // This is because the gateway doesn't just throw in this scenario, it crashes.
-    const mockExit = jest
-      .spyOn(process, 'exit')
-      .mockImplementation((code) => {
-        throw new Error(code?.toString());
-      });
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(code?.toString());
+    });
 
     const server = new ApolloServer({
       gateway,
@@ -111,15 +108,70 @@ describe('ApolloGateway executor', () => {
 
     // Ensure the throw happens to maintain the correctness of this test.
     await expect(
-      server.executeOperation({ query: '{ __typename }' })).rejects.toThrow();
+      server.executeOperation({ query: '{ __typename }' }),
+    ).rejects.toThrow();
 
     expect(server.requestOptions.executor).toBe(gateway.executor);
 
     expect(logger.error.mock.calls).toEqual([
-      ["Error checking for changes to service definitions: Tried to load services from remote endpoints but none provided"],
-      ["This data graph is missing a valid configuration. Tried to load services from remote endpoints but none provided"]
+      [
+        'Error checking for changes to service definitions: Tried to load services from remote endpoints but none provided',
+      ],
+      [
+        'This data graph is missing a valid configuration. Tried to load services from remote endpoints but none provided',
+      ],
     ]);
 
     mockExit.mockRestore();
+  });
+
+  it('should track query plan usage, and wait until they are finished to clean up', async () => {
+    const me = { id: '1', birthDate: '1988-10-21' };
+    fetch.mockJSONResponseOnce({ data: { me } });
+    fetch.mockJSONResponseOnce({ data: { me } });
+    const gateway = new ApolloGateway({
+      localServiceList: fixtures,
+    });
+
+    const { executor } = await gateway.load();
+
+    const source = `#graphql
+      query Me($locale: String) {
+        me {
+          id
+          birthDate(locale: $locale)
+        }
+      }
+    `;
+
+    const options = {
+      source,
+      document: gql(source),
+      request: {},
+      queryHash: 'hashed',
+      context: null,
+      cache: {} as any,
+      logger,
+    };
+
+    const one = executor(options);
+    const two = executor(options);
+
+    expect(gateway.hasBeenCleanedUp()).toBeFalsy();
+    gateway.cleanup();
+    expect(gateway.hasBeenCleanedUp()).toBeTruthy();
+
+    expect(gateway.getQueryPlanUsageForTesting()).toEqual(2);
+    const [oneData, twoData] = await Promise.all([one, two]);
+    expect(gateway.getQueryPlanUsageForTesting()).toEqual(0);
+
+    expect(oneData.errors).toBeFalsy();
+    expect(twoData.errors).toBeFalsy();
+    expect(oneData.data).toEqual({ me });
+    expect(twoData.data).toEqual({ me });
+
+    expect(() => executor(options)).toThrowErrorMatchingInlineSnapshot(
+      `"ApolloGateway used after 'cleanup()' called."`,
+    );
   });
 });

--- a/gateway-js/src/__tests__/gateway/refCounter.test.ts
+++ b/gateway-js/src/__tests__/gateway/refCounter.test.ts
@@ -1,0 +1,104 @@
+import RefCounter from '../../refCounter';
+
+// Get a promise that can be externally resolved.
+const resolvable = (): [() => void, Promise<void>] => {
+  let resolve = () => {}
+  let prom = new Promise<void>(res => resolve = res);
+  return [resolve, prom]
+}
+
+describe('RefCounter', () => {
+  it('should produce the contained value', () => {
+    const data = {};
+    let destruct = jest.fn();
+    let called = false;
+    new RefCounter(data, destruct).withBorrow((borrowed) => {
+      called = true;
+      expect(borrowed).toBe(data);
+    });
+    expect(called).toBeTruthy();
+  });
+
+  it('should release if immediately cleaned up', () => {
+    let destruct = jest.fn();
+    const data = {};
+    const counter = new RefCounter(data, destruct);
+    counter.cleanup();
+    expect(destruct).toBeCalledWith(data);
+  });
+
+  it('should prevent access after cleanup', () => {
+    let destruct = jest.fn();
+    const data = {};
+    const counter = new RefCounter(data, destruct);
+    counter.cleanup();
+    expect(destruct).toBeCalledWith(data);
+    expect(() =>
+      counter.withSyncBorrow(() => {}),
+    ).toThrowErrorMatchingInlineSnapshot(`"Cannot borrow a destructed value."`);
+  });
+
+  it('should wait to cleanup until usages have resolved', async () => {
+    const [resolve, prom] = resolvable();
+    let destruct = jest.fn();
+    const data = {};
+    const counter = new RefCounter(data, destruct);
+
+    const useProm = counter.withBorrow(() => prom);
+
+    counter.cleanup();
+    expect(destruct).not.toBeCalled()
+
+    resolve();
+    await useProm;
+
+    expect(destruct).toBeCalledWith(data);
+  });
+
+  it('should wait to cleanup until all usages have resolved (complex)', async () => {
+    const [resolve, prom] = resolvable();
+    const [resolve1, prom1] = resolvable();
+    const [resolve2, prom2] = resolvable();
+    const [resolve3, prom3] = resolvable();
+
+    let destruct = jest.fn();
+    const data = {};
+    const counter = new RefCounter(data, destruct);
+
+    const use = counter.withBorrow(() => prom);
+    const use1 = counter.withBorrow(() => prom1);
+    const use2 = counter.withBorrow(() => prom2);
+    const use3 = counter.withBorrow(() => prom3);
+
+    counter.cleanup();
+    expect(destruct).not.toBeCalled()
+
+    resolve();
+    await use;
+
+    expect(destruct).not.toBeCalled()
+
+    resolve1();
+    resolve2();
+    await use1;
+    await use2;
+
+    expect(destruct).not.toBeCalled()
+
+    // Here we have a hand-off -- another borrow is created before the
+    // current borrow is resolved.
+    const [resolve4, prom4] = resolvable();
+    const use4 = counter.withBorrow(() => prom4);
+
+    resolve3();
+    await use3;
+
+    expect(destruct).not.toBeCalled()
+
+    resolve4();
+    await use4;
+
+    expect(destruct).toBeCalledWith(data);
+  });
+
+});

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -112,9 +112,11 @@ export type Experimental_DidResolveQueryPlanCallback = ({
 }: {
   readonly queryPlan: QueryPlan;
   readonly serviceMap: ServiceMap;
-  // Note that the `queryPlanPointer` on the operation context is *not guarenteed
-  // to be valid*. It may be cleaned up at any point, you cannot assume that it
-  // can be passed to query-planner-wasm without error.
+  // Note that this `queryPlanPointer` on the operation context that's passed to
+  // didResolveQueryPlanCallback is *not guarenteed to be valid*.
+  // It is valid for the duration of the `_executor` call, but if you store the
+  // pointer from this callback lifecycle method and try to use it later, it
+  // might already have been disposed of on the rust side.
   readonly operationContext: OperationContext;
   readonly requestContext: GraphQLRequestContextExecutionDidStart<Record<string, any>>;
 }) => void;

--- a/gateway-js/src/refCounter.ts
+++ b/gateway-js/src/refCounter.ts
@@ -1,0 +1,62 @@
+// A reference counter to keep track of the rust pointer.
+
+export default class RefCounter<T> {
+  private contents: T | null;
+  private destruct: (arg: T) => void;
+  // RefCount starts at one, so that we don't destruct until
+  // `counter.cleanup()` is called.
+  private refCounts: number = 1;
+
+  constructor(value: T, destruct: (arg: T) => void) {
+    this.contents = value;
+    this.destruct = destruct;
+  }
+
+  private borrow(): T {
+    if (this.contents == null) {
+      throw new Error(`Cannot borrow a destructed value.`);
+    }
+    this.refCounts += 1;
+    return this.contents;
+  }
+
+  private release() {
+    if (this.contents == null) {
+      // releasing a destructed value is a no-op
+      return;
+    }
+    this.refCounts -= 1;
+    if (this.refCounts <= 0) {
+      this.destruct(this.contents);
+      this.contents = null;
+    }
+  }
+
+  public cleanup() {
+    this.release();
+  }
+
+  public withSyncBorrow<R>(fn: (arg: T) => R): R {
+    let res;
+    try {
+      res = fn(this.borrow());
+    } catch (err) {
+      this.release();
+      throw err;
+    }
+    this.release();
+    return res;
+  }
+
+  public async withBorrow<R>(fn: (arg: T) => Promise<R> | R): Promise<R> {
+    let res;
+    try {
+      res = await fn(this.borrow());
+    } catch (err) {
+      this.release();
+      throw err;
+    }
+    this.release();
+    return res;
+  }
+}

--- a/gateway-js/src/refCounter.ts
+++ b/gateway-js/src/refCounter.ts
@@ -1,62 +1,75 @@
-// A reference counter to keep track of the rust pointer.
+// A reference counter to keep track of rust pointers, which have to be manually destructed.
+
+// This data structure represents an individual "borrow". The number is just
+// for debugging purposes -- borrows are compared via reference equality,
+// not structural.
+type Borrow = {num: number};
 
 export default class RefCounter<T> {
   private contents: T | null;
   private destruct: (arg: T) => void;
-  // RefCount starts at one, so that we don't destruct until
-  // `counter.cleanup()` is called.
-  private refCounts: number = 1;
+  private refSet: Array<Borrow> = [];
+  private ownRef: Borrow | null;
+  private refCount: number = 0;
 
   constructor(value: T, destruct: (arg: T) => void) {
     this.contents = value;
     this.destruct = destruct;
+    // Have to keep track of our "own" reservation, so that the contents
+    // don't get cleaned up until after `.cleanupWhenReady()` is called.
+    this.ownRef = {num: this.refCount++};
+    this.refSet.push(this.ownRef);
   }
 
-  private borrow(): T {
+  private borrow(): [T, Borrow] {
     if (this.contents == null) {
       throw new Error(`Cannot borrow a destructed value.`);
     }
-    this.refCounts += 1;
-    return this.contents;
+    const ref = {num: this.refCount++}
+    this.refSet.push(ref);
+    return [this.contents, ref];
   }
 
-  private release() {
-    if (this.contents == null) {
-      // releasing a destructed value is a no-op
+  private release(ref: Borrow) {
+    const idx = this.refSet.indexOf(ref)
+    if (idx === -1) {
+      console.warn(`Double release! #${ref.num}`, new Error().stack)
       return;
     }
-    this.refCounts -= 1;
-    if (this.refCounts <= 0) {
+    if (this.contents == null) {
+      console.warn(`Contents were destroyed before a borrow #${ref.num} was released.`)
+      return;
+    }
+    this.refSet.splice(idx, 1);
+    if (this.refSet.length === 0) {
       this.destruct(this.contents);
       this.contents = null;
     }
   }
 
-  public cleanup() {
-    this.release();
-  }
-
-  public withSyncBorrow<R>(fn: (arg: T) => R): R {
-    let res;
-    try {
-      res = fn(this.borrow());
-    } catch (err) {
-      this.release();
-      throw err;
+  // Indicate that the contained value should be cleaned up after any
+  // outstanding borrows have been returned.
+  public cleanupWhenReady() {
+    if (this.ownRef) {
+      this.release(this.ownRef);
+      this.ownRef = null;
+    } else {
+      console.warn(`Trying to cleanupWhenReady() twice. This is a no-op.`);
     }
-    this.release();
-    return res;
   }
 
+  // Safely borrow the contained value for an async procedure; the contents
+  // will not be destructed before the function's return promise has resolved.
   public async withBorrow<R>(fn: (arg: T) => Promise<R> | R): Promise<R> {
     let res;
+    const [value, ref] = this.borrow();
     try {
-      res = await fn(this.borrow());
+      res = await fn(value);
     } catch (err) {
-      this.release();
+      this.release(ref);
       throw err;
     }
-    this.release();
+    this.release(ref);
     return res;
   }
 }


### PR DESCRIPTION
## Summary:
The gateway "unreachable" errors we've been getting have come from requests trying to use a rust-side query planner
that had already been "dropped". This changes the ApolloGateway to be more conservative, waiting to drop all
query planners until `.cleanup()` is explicitly called, and also waiting until any in-flight requests have finished being processed.

Issue: INFRA-5885

## Test plan:
`yarn test`, all passing